### PR TITLE
Setup HEMTT Binarization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 release/*
 releases/*
 keys/*
+z/*
+a3/*
 .hemtt/local
 *.cache
 *.pbo

--- a/addons/insignia/CfgUnitInsignia.hpp
+++ b/addons/insignia/CfgUnitInsignia.hpp
@@ -2,5 +2,9 @@ class CfgUnitInsignia
 {
     #include "players\insignia.hpp"
     #include "squad\insignia.hpp"
+<<<<<<< Updated upstream
 	#include "respect\insignia.hpp"
+=======
+    #include "respect\insignia.hpp"
+>>>>>>> Stashed changes
 };

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches
         author="Walthzer/Shark";
         url="https://whitefoxassaultreg.wixsite.com/wfar";
         requiredVersion=1.6;
-        requiredaddons[]={ "A3_Data_F_Enoch_Loadorder" };
+        requiredaddons[]={ "CBA_main", "A3_Data_F_Enoch_Loadorder" };
         units[]={};
         weapons[]={};
     };

--- a/hemtt.toml
+++ b/hemtt.toml
@@ -1,6 +1,9 @@
 name = "WFAR"
 prefix = "wfar"
 author = "Walthzer/Shark"
+check = [
+    "!binarizer_link"
+]
 files = [
     "*.so",
     "mod.cpp",
@@ -32,3 +35,11 @@ releasebuild = [
 
 [header_exts]
 version= "{{git \"id 8\"}}"
+
+# Binarizer file search compatibility
+[scripts.binarizer_link]
+steps_windows = [
+    "if not exist z\\wfar mkdir z\\wfar",
+    "if not exist z\\wfar\\addons mklink /j z\\wfar\\addons addons",
+    "if not exist a3 mklink /j a3 N:\\Arma3Pdrive\\a3"
+]


### PR DESCRIPTION
After fixing the registery keys for Binarize we encountered some issues.

HEMTT.toml now create a few links to help binarize resolve filepaths.